### PR TITLE
Use pipes to communicate with mathjax; add asciimath support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,5 @@ $ manimgl-mathjax install
 
 ## Usage
 Just use `JTex` instead of [`MTex`](https://github.com/3b1b/manim/pull/1725#issue-1121866424)
+
+Use `AM` to write math in [asciimath](http://asciimath.org/) notation, [see also](https://zmx0142857.gitee.io/note/#math).

--- a/manimgl_mathjax/__init__.py
+++ b/manimgl_mathjax/__init__.py
@@ -2,4 +2,4 @@ import pkg_resources
 
 __version__ = pkg_resources.get_distribution("manimgl_mathjax").version
 
-from .mathjax import JTex
+from .mathjax import JTex, AM

--- a/manimgl_mathjax/index.js
+++ b/manimgl_mathjax/index.js
@@ -1,5 +1,40 @@
-const fs = require('fs')
-const tex2svg = require('./tex2svg.js')
+/**
+ * This file reads asciimath string from stdin and output svg formula to
+ * stdout.  On linux you can end the input with ctrl-d; unfortunately on
+ * windows this is not possible, so you may use ctrl-c to interrupt the
+ * input.
+ *
+ * Another option is to redirect from file:
+ *   $ node index.js < input.txt
+ * On windows, quote is needed:
+ *   $ "node" index.js < input.txt
+ */
 
-let { argv } = process
-tex2svg(argv[3]).then(svg => fs.writeFileSync(argv[2], svg))
+const { am2tex } = require('asciimath-js')
+const tex2svg = require('./tex2svg.js')
+const { stdin, stdout } = process
+const buf = []
+
+stdin.setEncoding('utf8')
+
+stdin.on('readable', () => {
+  let data
+  while ((data = stdin.read()) !== null) {
+    buf.push(data.trim())
+  }
+})
+
+const convert = process.argv[2] === '--am'
+  ? (input) => tex2svg(am2tex(input))
+  : tex2svg
+
+function onEnd () {
+  const input = buf.join('\n')
+  convert(input).then(svg => {
+    console.log(svg)
+    process.exit()
+  })
+}
+
+stdin.on('end', onEnd)
+process.on('SIGINT', onEnd)

--- a/manimgl_mathjax/package.json
+++ b/manimgl_mathjax/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "asciimath-js": "^1.0.1",
     "mathjax-full": "^3.2.0"
   },
   "name": "manim-mathjax",


### PR DESCRIPTION
## Changes

- Use pipes (instead of command line arguments) to send tex string to mathjax. No quotes or escapes are needed in the tex strings then. Pipes may perform better than command lines but I have no evidence though.
- Add [asciimath](http://asciimath.org) support to make math markup easier. To enable this, rerun `npm install` in the directory of `package.json`.
